### PR TITLE
Stop ignoring README.md

### DIFF
--- a/layer.yaml
+++ b/layer.yaml
@@ -1,3 +1,1 @@
 includes: ['layer:basic']
-ignore:
-  - 'README.md'


### PR DESCRIPTION
Although that should be expected to work, the current charm
build behavior is that any ignore declarations at any layer,
both lower and higher levels, will be ignored during build.

That means that this declaration causes the top layer's
README.md to also be dropped and not included in the build.

This behavior is believed to be a bug, but pending resolution
within the tools, assume ignores are global to the whole
build stack.

Reference:  https://github.com/juju/charm-tools/issues/220
